### PR TITLE
Vercel deployment errors

### DIFF
--- a/web-app/karaoke/vercel.json
+++ b/web-app/karaoke/vercel.json
@@ -1,0 +1,5 @@
+{
+   "rewrites":  [
+       {"source": "/(.*)", "destination": "/"}
+    ]
+}

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "web-app",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Removed package-lock.json and added vercel.json instead to allow the routing to work within the application. 